### PR TITLE
Upload.php: Return the same JSON Structure for files that are already existing

### DIFF
--- a/api/upload.php
+++ b/api/upload.php
@@ -37,20 +37,14 @@ if ($_FILES['file']["error"] == UPLOAD_ERR_OK)
     $sha1 = sha1_file($_FILES['file']["tmp_name"]);
     $ehash = sha1Exists($sha1);
     if($ehash && file_exists(ROOT.DS.'data'.DS.$ehash.DS.$ehash)) {
-        $earray = array(
-			'status'=>'ok',
-	    	'hash'=>$ehash,
-			'filetype'=>$type,
-			'url'=>URL.$ehash
-		);
-		if(getDeleteCodeOfHash($ehash))
+        $earray = array('status'=>'ok','hash'=>$ehash,'filetype'=>$type,'url'=>URL.$ehash);
+	if(getDeleteCodeOfHash($ehash))
         {
             $earray['delete_code'] = getDeleteCodeOfHash($ehash);
             $earray['delete_url'] = URL.'delete_'.getDeleteCodeOfHash($ehash).'/'.$ehash;
         }
-		exit(json_encode($earray));
+	exit(json_encode($earray));
     }
-       
 
     //cross check filetype for controllers
     //

--- a/api/upload.php
+++ b/api/upload.php
@@ -36,8 +36,21 @@ if ($_FILES['file']["error"] == UPLOAD_ERR_OK)
     //check for duplicates
     $sha1 = sha1_file($_FILES['file']["tmp_name"]);
     $ehash = sha1Exists($sha1);
-    if($ehash && file_exists(ROOT.DS.'data'.DS.$ehash.DS.$ehash))
-        exit(json_encode(array('status'=>'ok','hash'=>$ehash,'filetype'=>$type,'url'=>URL.$ehash)));
+    if($ehash && file_exists(ROOT.DS.'data'.DS.$ehash.DS.$ehash)) {
+        $earray = array(
+			'status'=>'ok',
+	    	'hash'=>$ehash,
+			'filetype'=>$type,
+			'url'=>URL.$ehash
+		);
+		if(getDeleteCodeOfHash($ehash))
+        {
+            $earray['delete_code'] = getDeleteCodeOfHash($ehash);
+            $earray['delete_url'] = URL.'delete_'.getDeleteCodeOfHash($ehash).'/'.$ehash;
+        }
+		exit(json_encode($earray));
+    }
+       
 
     //cross check filetype for controllers
     //


### PR DESCRIPTION
Hey there,

I was integrating Pictshare's API in the Screenshot Tool ShareX and struggling for an hour, wondering why the Script did not return the `delete_url` param.

Eventually I found out this was related to Sharex Uploading the same file over and over again to test and the /upload endpoint returning a different JSON Structure for files that have been uploaded before. 

So I created this PR which returns the Same values as if the file uploaded would not have been uploaded before.