### PR TITLE
Adds PowerShell script for Greenshot on Windows

### DIFF
--- a/rtfm/INTEGRATIONS.md
+++ b/rtfm/INTEGRATIONS.md
@@ -44,3 +44,67 @@ result=$(curl -s -F "file=@${1}" https://pictshare.net/api/upload.php | jq -r .u
 xclip -selection clipboard -t image/png -i $1
 google-chrome $result
 ```
+
+# Screenshot to pictshare (windows)
+
+This script will upload a screenshot from [Greenshot](https://getgreenshot.org/) to PictShare with the help of a PowerShell script.
+
+Requirements:
+- curl (choco install curl)
+- [PowerShell 7](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
+
+Configure Greenshot:
+- Settings -> Output
+  - Storage location: C:\Temp\
+  - Filename pattern: GreenShot
+  - Image format: jpg
+Create a new External command, under Settings -> Plugins -> Click on External command Plugin -> Configure -> New
+- Name: what ever you want here
+- Command: find and point to pwsh.exe
+- Argument: -F Path\to\this\script -Address consto.com
+
+Create a PowerShell script with the code below.
+
+Feel free to change "C:\Temp\GreenShot.jpg" and "C:\Temp\pictshare_posts.json" to match your needs.
+
+pictshare_posts.json is useful for logging and automating deleting old uploads.
+
+```powershell
+#Requires -Version 7
+
+param (
+    # Change the base url to match your Pictshare server
+    [Parameter(Mandatory)][string]$Address,
+    # Change path of where you expect the jpg file to be
+    [string]$File = "C:\Temp\GreenShot.jpg",
+    # Log file of all requests
+    [string]$LogFile = "C:\Temp\pictshare_posts.json",
+    # Use http and not https
+    [switch]$IsNotHttps,
+    # Do not save url to upload to the clipboard
+    [switch]$NoSaveToClipboard
+)
+begin {
+    $Protocol = if ($IsNotHttps){
+        "http:"
+    }else{
+        "https:"
+    }
+}
+process {
+    # Upload screenshot
+    $Response = $(curl -s -F "file=@$File" $Protocol//$Address/api/upload.php) | ConvertFrom-Json
+    if ($Response.status -like "ok") {
+        if ($NoSaveToClipboard){
+            # Don't save url to clipboard
+        }else{
+            Set-Clipboard -Value $Response.url
+        }
+    }
+    # Output response back from the pictshare server
+    if($Response){
+        $Response | ConvertTo-Json | Out-File -FilePath $LogFile -Append
+    }
+}
+end {}
+```

--- a/rtfm/INTEGRATIONS.md
+++ b/rtfm/INTEGRATIONS.md
@@ -61,7 +61,7 @@ Configure Greenshot:
 Create a new External command, under Settings -> Plugins -> Click on External command Plugin -> Configure -> New
 - Name: what ever you want here
 - Command: find and point to pwsh.exe
-- Argument: -F Path\to\this\script -Address consto.com
+- Argument: -w Hidden -F Path\to\this\script -Address consto.com
 
 Create a PowerShell script with the code below.
 


### PR DESCRIPTION
Came across PictShare when I was looking for a self hosted imgur replacement. I use Greenshot on windows and wanted an easy way to upload screenshots.

So I figured out how to with a bit of PowerShell. Sadly it does need Curl as Invoke-WebRequest and Invoke-RestMethod don't like uploading files easily. Curl simplified the process by reducing 10's of lines of code to one line of code. This script also saves the responses to a file for easier parsing; if for say a user wants to [automate deletion](https://gist.github.com/quonic/bbc19d957ff960726ff4cb15f7c8adfe) or anything else.