### PR TITLE
Add JPEG EXIF orientation rotation

### DIFF
--- a/content-controllers/image/image.controller.php
+++ b/content-controllers/image/image.controller.php
@@ -24,8 +24,26 @@ class ImageController implements ContentController
             case 17: $ext = 'ico';break;  // ico
             case 18: $ext = 'webp';break; // webp
 
-            case 2: //we clean up exif data of JPGs so GPS and other data is removed
+            case 2:
+                //we clean up exif data of JPGs so GPS and other data is removed
                 $res = imagecreatefromjpeg($tmpfile);
+
+                // rotate based on EXIF Orientation
+                $exif = exif_read_data($tmpfile);
+                if (!empty($exif['Orientation'])) {
+                    switch ($exif['Orientation']) {
+                        case 3:
+                            $res = imagerotate($res, 180, 0);
+                            break;
+                        case 6:
+                            $res = imagerotate($res, -90, 0);
+                            break;
+                        case 8:
+                            $res = imagerotate($res, 90, 0);
+                            break;
+                    }
+                }
+
                 imagejpeg($res, $tmpfile, (defined('JPEG_COMPRESSION')?JPEG_COMPRESSION:90));
                 $ext = 'jpg';
             break;

--- a/content-controllers/image/image.controller.php
+++ b/content-controllers/image/image.controller.php
@@ -32,12 +32,29 @@ class ImageController implements ContentController
                 $exif = exif_read_data($tmpfile);
                 if (!empty($exif['Orientation'])) {
                     switch ($exif['Orientation']) {
+                        case 2:
+                            imageflip($res, IMG_FLIP_HORIZONTAL);
+                        case 1:
+                            // Nothing to do
+                            break;
+
+                        case 4:
+                            imageflip($res, IMG_FLIP_HORIZONTAL);
+                            // Also rotate
                         case 3:
                             $res = imagerotate($res, 180, 0);
                             break;
+
+                        case 5:
+                            imageflip($res, IMG_FLIP_VERTICAL);
+                            // Also rotate
                         case 6:
                             $res = imagerotate($res, -90, 0);
                             break;
+
+                        case 7:
+                            imageflip($res, IMG_FLIP_VERTICAL);
+                            // Also rotate
                         case 8:
                             $res = imagerotate($res, 90, 0);
                             break;

--- a/rtfm/DOCKER.md
+++ b/rtfm/DOCKER.md
@@ -11,7 +11,7 @@ docker run -d -p 80:80 -e "TITLE=My own PictShare" -e "URL=http://localhost/" gh
 
 ### Building it
 ```bash
-docker build -t pictshare .
+docker build -t pictshare -f docker/Dockerfile .
 ```
 
 ### Quick start


### PR DESCRIPTION
Fixes https://github.com/HaschekSolutions/pictshare/issues/65. Rotate JPEGs by their Orientation EXIF tag before removing the tags.

I also updated the Docker build instructions as I think they were out of date.