### PR TITLE
Fix for deprecated features in PHP 8.1

### DIFF
--- a/inc/core.php
+++ b/inc/core.php
@@ -425,7 +425,7 @@ function getUserIP()
 	$forward = @$_SERVER['HTTP_X_FORWARDED_FOR'];
 	$remote  = $_SERVER['REMOTE_ADDR'];
 	
-    if(strpos($forward,','))
+    if($forward != null && strpos($forward,','))
     {
         $a = explode(',',$forward);
         $forward = trim($a[0]);


### PR DESCRIPTION
```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string
```
ref.  https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal

![image](https://github.com/HaschekSolutions/pictshare/assets/941609/c3107c74-c366-4dde-87c2-680a90522ae6)
