### PR TITLE
Change Input field to password type

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -65,7 +65,7 @@
                                 echo "Allowed file types: ". implode(', ',getAllContentFiletypes());
 
                                 if(defined('UPLOAD_CODE') && UPLOAD_CODE!='')
-                                    echo '<br>Upload Code: <input type="text" id="uploadcode"  />';
+                                    echo '<br>Upload Code: <input type="password" id="uploadcode"  />';
                             ?>
                         </p>
                             <form class="dropzone well" id="dropzone" method="post" action="/api/upload.php" enctype="multipart/form-data">


### PR DESCRIPTION
Change the input box for Upload Code on main page from `type='text'` to `type='password'` to hide the upload code while on-screen and signal to browsers to prompt to save the code in their password managers.